### PR TITLE
Reduce the Flatpak size

### DIFF
--- a/org.kde.kdiff3.json
+++ b/org.kde.kdiff3.json
@@ -11,6 +11,12 @@
         "--socket=fallback-x11",
         "--socket=wayland"
     ],
+     "cleanup": [
+        "/include",
+        "/lib/cmake",
+        "/share/doc",
+        "/share/man"
+    ],
     "modules": [
         {
             "name": "boost",


### PR DESCRIPTION
The installed size reduced from 159.4 MB to 2.4 MB.

Remove development related files to reduce Flatpak size.